### PR TITLE
chore: Remove unnecessary regex manager for asdf

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -36,14 +36,4 @@
       automergeType: "branch",
     },
   ],
-  regexManagers: [
-    // Node.js with asdf
-    {
-      fileMatch: ["^.tool-versions$"],
-      matchStrings: ["^nodejs (?<currentValue>.*)\\n"],
-      depNameTemplate: "nodejs/node",
-      versioningTemplate: "node",
-      datasourceTemplate: "node",
-    },
-  ],
 }


### PR DESCRIPTION
Added support for .tools-versions as used by asdf in [v31.199.0](https://github.com/renovatebot/renovate/releases/tag/32.199.0)